### PR TITLE
Added scripts and css for menu button for mobile version

### DIFF
--- a/wpa_project/student_app/static/css/styles.css
+++ b/wpa_project/student_app/static/css/styles.css
@@ -5,6 +5,40 @@
   --color-dark-brown: #372a13;
 }
 
+/* Mobile and Small Screens */
+@media only screen and (max-width: 770px) {
+  #menu-button {
+    display: inline-flex;
+  }
+  
+  .navbar-nav {
+    display: none;    
+  }
+
+  .navbar-custom {
+    clear: both;
+  }
+
+  .login-container {
+    display: none;
+  }
+}
+
+/* Larger Screens */
+@media only screen and (min-width: 771px) {
+  #menu-button {
+    display: none;
+  }
+
+  .navbar-nav {
+    display: inline-flex;
+  }
+
+  .navbar-custom {
+    float: left;
+  }
+}
+
 nav .navbar-brand
 {
     /* size for brand */
@@ -136,7 +170,6 @@ hr {
   font-size: 16px;
 }
 
-
 a {
   color: #17a2b8;
 }
@@ -176,6 +209,12 @@ a {
   border: 1px solid white;
 }
 
+/* SVG */
+
+svg {
+  fill: white;
+}
+
 /* NAVIGATION BAR */
 
 #navbar {
@@ -188,7 +227,6 @@ a {
 
 .navbar-custom {
   width: fit-content;
-  float: left;
 }
 
 .navbar-right-container {
@@ -196,13 +234,19 @@ a {
   display: inline-flex;
 }
 
+#menu-button {
+  margin: 0.5rem;
+  width: 50px;
+  float: left;
+}
+
 /* SOCIAL MEDIA LINKS */
 
 .navbar-right-container svg {
-  fill: white;
   margin: 0.5rem 0.1rem;
   padding: 0.2rem;
 }
+
 
 /* LOGIN BAR */
 

--- a/wpa_project/student_app/static/js/ui.js
+++ b/wpa_project/student_app/static/js/ui.js
@@ -1,0 +1,27 @@
+// Scripts to deal with UI functionality
+
+const mobileWidth = 770;  // Size at which we will use mobile settings for UI
+
+$(document).ready(function() {
+    var menuItems = $(".navbar-nav");   // Navigation bar's contents
+
+    // Change UI when window is resized
+    window.onresize = function() {
+        /*// Show navigation links if we're over a certain width
+        if (window.innerWidth > mobileWidth) {
+            menuItems.show();
+            //$(".navbar-custom").css("{ float: left, clear: '' }");
+        }
+        else {
+            menuItems.hide();
+        }*/
+    }
+
+    // Hide and show menu items when button is clicked on smaller screens
+    $("#menu-button").on("click", function() {
+        if (menuItems.css("display") == "none")
+            menuItems.show();
+        else
+            menuItems.hide();
+    })
+});

--- a/wpa_project/student_app/templates/nav.html
+++ b/wpa_project/student_app/templates/nav.html
@@ -1,6 +1,15 @@
 {% load static %}
+<script src="{% static 'js/ui.js' %}"></script>
 <nav id="navbar-container" class="navbar-dark bg-dark border">
     <div id="navbar" class="navbar-expand-md" >
+        <div id="menu-button">
+            <svg class="svg" viewBox="0 0 20 20">
+                <path d="M3.314,4.8h13.372c0.41,0,0.743-0.333,0.743-0.743c0-0.41-0.333-0.743-0.743-0.743H3.314
+                    c-0.41,0-0.743,0.333-0.743,0.743C2.571,4.467,2.904,4.8,3.314,4.8z M16.686,15.2H3.314c-0.41,0-0.743,0.333-0.743,0.743
+                    s0.333,0.743,0.743,0.743h13.372c0.41,0,0.743-0.333,0.743-0.743S17.096,15.2,16.686,15.2z M16.686,9.257H3.314
+                    c-0.41,0-0.743,0.333-0.743,0.743s0.333,0.743,0.743,0.743h13.372c0.41,0,0.743-0.333,0.743-0.743S17.096,9.257,16.686,9.257z"></path>
+            </svg>
+        </div>
         <ul class="navbar-nav md-auto mt-2 navbar-custom">
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-expanded="false">


### PR DESCRIPTION
**Changes:**
- Added a menu button that replaces the main navigation bar when on a screen with a smaller width. Pressing the button will expand the menu to show the full navigation bar.

**Known Issues:**
- If on a browser, if the menu button is interacted with and we resize the window to something larger, it will cause issues with the navigation. The navigation links will either disappear or be displayed incorrectly depending on whether we resized when the menu is expanded or not.

**To-Do:**
- Make a mobile-friendly version of navigation links.
- Add a "log in" button on the right for easier access to login screen on mobile.