### PR TITLE
Student updates by staff

### DIFF
--- a/wpa_project/contact_us/tests/tests_complaint.py
+++ b/wpa_project/contact_us/tests/tests_complaint.py
@@ -85,7 +85,7 @@ class TestsComplaint(TestCase):
         self.assertTrue(be[0].body.find('Charles Wells') > 0)
         self.assertIsNone(Complaint.objects.last().resolved_date)
 
-    @tag('temp')
+    # @tag('temp')
     def test_post_complaint_resolved(self):
         self.add_message()
         self.post_dict['form-0-complaint'] = self.complaint.id,

--- a/wpa_project/joad/templates/joad/index.html
+++ b/wpa_project/joad/templates/joad/index.html
@@ -72,7 +72,7 @@
         <tbody id="class-list-body">
             {% for session in session_list %}
                 <tr>
-                    {% if user.is_board %}
+                    {% if user.is_staff %}
                         <td>
                             <a href="{% url 'joad:session' session.id %}">{{ session.start_date }}</a>
                         </td>
@@ -105,7 +105,7 @@
         </tbody>
     </table>
     <div id="class-div"></div>
-    {% if user.is_board %}
+    {% if user.is_staff %}
         <div class="m-3">
             <a href="{% url 'joad:session' %}" class="btn btn-primary" role="button">New Session</a>
         </div>

--- a/wpa_project/joad/templates/joad/tables/events.html
+++ b/wpa_project/joad/templates/joad/tables/events.html
@@ -14,7 +14,7 @@
         {% for event in event_list %}
             <tr>
                 <td>
-                    {% if user.is_board %}
+                    {% if user.is_staff %}
                         <a class="nav-link" href="{% url 'joad:event' event.id %}">{{ event.event_date }}</a>
                     {% else %}
                         {{ event.event_date }}

--- a/wpa_project/joad/tests/tests_attendance.py
+++ b/wpa_project/joad/tests/tests_attendance.py
@@ -1,7 +1,7 @@
 import logging
 import json
 from django.apps import apps
-from django.test import TestCase, Client
+from django.test import TestCase, Client, tag
 from django.urls import reverse
 
 from student_app.models import Student
@@ -26,23 +26,26 @@ class TestsJoadAttendance(TestCase):
         response = self.client.get(reverse('joad:attendance'), secure=True)
         self.assertEqual(response.status_code, 403)
 
+    # @tag('temp')
     def test_staff_user_get_no_class(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
 
         response = self.client.get(reverse('joad:attendance'), secure=True)
         self.assertEqual(response.status_code, 404)
 
+    # @tag('temp')
     def test_staff_user_get(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
 
         response = self.client.get(reverse('joad:attendance', kwargs={'class_id': 1}), secure=True)
         self.assertEqual(len(response.context['object_list']), 4)
         self.assertTemplateUsed(response, 'joad/attendance.html')
 
+    # @tag('temp')
     def test_staff_user_get_attended(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
 
         jc = JoadClass.objects.get(pk=1)
@@ -62,7 +65,7 @@ class TestsJoadAttendance(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_staff_user_post_attend(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
 
         response = self.client.post(reverse('joad:attend', kwargs={'class_id': 1}), {'check_8': True}, secure=True)
@@ -72,7 +75,7 @@ class TestsJoadAttendance(TestCase):
         self.assertTrue(a[0].attended)
 
     def test_staff_user_post_unattend(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
         jc = JoadClass.objects.get(pk=1)
         student = Student.objects.get(pk=8)
@@ -86,7 +89,7 @@ class TestsJoadAttendance(TestCase):
         self.assertFalse(a[0].attended)
 
     def test_staff_user_post_attend_error(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
 
         response = self.client.post(reverse('joad:attend', kwargs={'class_id': 1}), {}, secure=True)

--- a/wpa_project/student_app/tests/tests_student.py
+++ b/wpa_project/student_app/tests/tests_student.py
@@ -105,7 +105,7 @@ class TestsStudent(TestCase):
 
     # @tag("temp")
     def test_post_student_id_staff(self):
-        self.test_user = User.objects.get(pk=1)
+        self.test_user = User.objects.get(pk=2)
         self.client.force_login(self.test_user)
         d = {"first_name": "Kiley", "last_name": "Conlan", "dob": "1995-12-03", "is_staff": "on"}
         response = self.client.post(reverse('registration:add_student', kwargs={'student_id': 6}), d, secure=True)
@@ -113,6 +113,7 @@ class TestsStudent(TestCase):
         self.assertEqual(student.first_name, d['first_name'])
         self.assertEqual(student.last_name, d['last_name'])
         self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(student.student_family.id, 4)
 
 
     # @tag("temp")


### PR DESCRIPTION
making it so that non-board users can update student profile properly.
changing board to staff in joad templates to allow staff to update.

Issue #195 